### PR TITLE
Fix second submission deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -9,7 +9,7 @@
   link: https://www.ieee-security.org/TC/SP2025
   deadline:
     - "2024-06-06 23:59"
-    - "2024-12-14 23:59"
+    - "2024-11-14 23:59"
   place: San Francisco, California, USA
   tags: [SEC, PRIV, CONF]
 


### PR DESCRIPTION
The second submission deadline for Oakland is November 14th and not December. See the [call for papers](https://www.ieee-security.org/TC/SP2025/cfpapers.html)